### PR TITLE
Moved dependencies to docker-compose for better version control

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,14 @@
-ARG UBUNTU_VERSION=20.04
-FROM ubuntu:${UBUNTU_VERSION} as system_deps
+ARG UBUNTU_VERSION
+FROM ubuntu:${UBUNTU_VERSION} AS system_deps
 ENV DEBIAN_FRONTEND=nonintercative
 RUN mkdir -p /app/src
 WORKDIR /app
 
 # system_deps args
-ARG IOHK_LIBSODIUM_GIT_REV=66f017f16633f2060db25e17c170c2afa0f2a8a1
-ARG IOKH_LIBSECP251_GIT_REV=ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+ARG IOHK_LIBSODIUM
+ARG IOHK_LIBSODIUM_GIT_REV
+ARG BTC_LIBSECP251
+ARG BTC_LIBSECP251_GIT_REV
 
 # development dependencies
 RUN apt-get update -y && apt-get install -y \
@@ -31,39 +33,40 @@ RUN apt-get update -y && apt-get install -y \
   tmux \
   wget \
   zlib1g-dev libreadline-dev llvm libnuma-dev \
+  cmake \
   && rm -rf /var/lib/apt/lists/*
 
 # install secp2561k library with prefix '/'
-RUN git clone https://github.com/bitcoin-core/secp256k1 &&\
+RUN git clone ${BTC_LIBSECP251} &&\
   cd secp256k1 \
   && git fetch --all --tags &&\
-  git checkout ${IOKH_LIBSECP251_GIT_REV} \
+  git checkout ${BTC_LIBSECP251_GIT_REV} \
   && ./autogen.sh && \
   ./configure --prefix=/usr --enable-module-schnorrsig --enable-experimental && \
   make && \
   make install  && cd .. && rm -rf ./secp256k1
 
-FROM system_deps as haskell
+FROM system_deps AS haskell
 
 # haskell args
-ARG CABAL_VERSION=3.6.2.0
-ARG GHC_VERSION=8.10.7
-ARG HLS_VERSION=1.7.0.0
+ARG CABAL_VERSION
+ARG GHC_VERSION
+ARG HLS_VERSION
 
 # install libsodium from sources with prefix '/'
-RUN git clone https://github.com/input-output-hk/libsodium.git &&\
+RUN git clone ${IOHK_LIBSODIUM} &&\
   cd libsodium \
   && git fetch --all --tags &&\
   git checkout ${IOHK_LIBSODIUM_GIT_REV} \
   && ./autogen.sh && \
   ./configure --prefix=/usr && \
   make && \
-  make install  && cd .. && rm -rf ./libsodium
+  make install && cd .. && rm -rf ./libsodium
 
 # install ghcup
 ENV PATH=${PATH}:${HOME:-/root}/.ghcup/bin
 RUN wget --secure-protocol=TLSv1_2 \
-  https://downloads.haskell.org/~ghcup/$(arch)-linux-ghcup  \ 
+  https://downloads.haskell.org/~ghcup/$(arch)-linux-ghcup \ 
   && chmod +x $(arch)-linux-ghcup \
   && mkdir -p ${HOME:-/root}/.ghcup/bin \
   && mv $(arch)-linux-ghcup ${HOME:-/root}/.ghcup/bin/ghcup 
@@ -81,19 +84,24 @@ RUN cabal update
 # Add cabal to PATH
 RUN echo "export PATH=$PATH:/root/.cabal/bin" >> ~/.bashrc
 
-FROM haskell as cardano_cli
+ARG CARDANO_NODE_VERSION
+ARG CARDANO_CLI_VERSION
+ARG STYLISH_HASKELL_VERSION
+ARG NODE_VERSION
+FROM haskell AS cardano_cli
 
 # install cardano-cli (we use a different docker container for the actual node)
-# (These have to be the same version as the cardano-node image specified at `docker-compose.yml`)
-RUN wget https://github.com/rober-m/cardano-node/releases/download/1.35.5/$(arch)-linux-cardano-cli
-RUN chmod +x $(arch)-linux-cardano-cli
-RUN mv $(arch)-linux-cardano-cli /usr/bin/cardano-cli
+RUN wget https://github.com/IntersectMBO/cardano-cli/releases/download/cardano-cli-${CARDANO_CLI_VERSION}/cardano-cli-9.2.1.0-$(arch)-linux.tar.gz \
+    && tar -xzvf cardano-cli-${CARDANO_CLI_VERSION}-$(arch)-linux.tar.gz \
+    && mv cardano-cli-$(arch)-linux /usr/bin/cardano-cli \
+    && chmod +x /usr/bin/cardano-cli \
+    && rm -rf cardano-cli-${CARDANO_CLI_VERSION}-$(arch)-linux.tar.gz
 
 # node socket
 RUN echo "export CARDANO_NODE_SOCKET_PATH=/root/.cardano/preview/node.socket" >> ~/.bashrc
 RUN echo "export NETWORK=preview" >> ~/.bashrc
 
-FROM cardano_cli as kuber
+FROM cardano_cli AS kuber
 
 # install kuber
 RUN wget https://github.com/rober-m/kuber/releases/download/babbage-era/$(arch)-linux-kuber
@@ -101,21 +109,21 @@ RUN chmod +x $(arch)-linux-kuber
 RUN mv $(arch)-linux-kuber /usr/bin/kuber
 
 
-FROM kuber as stylish_haskell
+FROM kuber AS stylish_haskell
 
 # install stylish-haskell (FIXME: couldn't compile a bin for arm64)
 # RUN wget https://github.com/rober-m/stylish-haskell/releases/download/v0.14.3.0/$(arch)-linux-stylish-haskell
 # RUN chmod +x $(arch)-linux-stylish-haskell
 # RUN mv $(arch)-linux-stylish-haskell /usr/bin/stylish-haskell
-RUN wget https://github.com/rober-m/stylish-haskell/releases/download/v0.14.3.0/x86_64-linux-stylish-haskell
+RUN wget https://github.com/rober-m/stylish-haskell/releases/download/v${STYLISH_HASKELL_VERSION}/x86_64-linux-stylish-haskell
 RUN chmod +x x86_64-linux-stylish-haskell
 RUN mv x86_64-linux-stylish-haskell /usr/bin/stylish-haskell
 
-FROM kuber as nodejs
+FROM kuber AS nodejs
 
-ENV NODE_VERSION=16.13.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
+ENV NODE_VERSION=${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
@@ -123,26 +131,26 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
-FROM nodejs as plutus
+FROM nodejs AS plutus
 
 RUN git clone https://github.com/input-output-hk/plutus-pioneer-program
 RUN cd plutus-pioneer-program/code && cabal update
-RUN cd plutus-pioneer-program/code && cabal build all
+#RUN cd plutus-pioneer-program/code && cabal build all
 
 RUN echo "alias serve-docs='python3 -m http.server -d /workspace/docs/plutus-docs/haddock/'" >> ~/.bashrc
 RUN echo "source <(cardano-cli --bash-completion-script cardano-cli)" >> ~/.bashrc
 
-FROM plutus as cargo
+FROM plutus AS cargo
 
 RUN curl https://sh.rustup.rs -sSfo rustup-init
 RUN chmod +x rustup-init
 RUN ./rustup-init -y
 
-FROM cargo as deno
+FROM cargo AS deno
 
 RUN /root/.cargo/bin/cargo install deno --locked
 
-FROM deno as testing-docs
+FROM deno AS testing-docs
 
 RUN /root/.cargo/bin/cargo install mdbook
 RUN echo "alias serve-testing-docs='mdbook serve /workspace/docs/psm-docs'" >> ~/.bashrc

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,10 +1,9 @@
-version: "3.5"
 volumes:
   node-ipc:
   node-db:
 services:
   cardano-node:
-    image: robertinoiog/cardano-node:1.35.5-v3
+    image: ghcr.io/intersectmbo/cardano-node:9.1.1
     environment:
       NETWORK: ${NETWORK:-preview}
     volumes:
@@ -16,8 +15,22 @@ services:
         max-size: "200k"
         max-file: "10"
   ppp:
-    image: robertinoiog/plutus-pioneer-program-4:v6
-    # build: .
+    build:
+      context: .
+      # These are the environment variables for dependencies,
+      # grouped in one place for better version control.
+      args:
+        UBUNTU_VERSION: 22.04
+        IOHK_LIBSODIUM: 'https://github.com/IntersectMBO/libsodium.git'
+        IOHK_LIBSODIUM_GIT_REV: 1736ff8
+        BTC_LIBSECP251: 'https://github.com/bitcoin-core/secp256k1.git'
+        BTC_LIBSECP251_GIT_REV: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+        CARDANO_CLI_VERSION: 9.2.1.0
+        CABAL_VERSION: 3.12.1.0
+        GHC_VERSION: 8.10.7
+        HLS_VERSION: 2.2.0.0
+        STYLISH_HASKELL_VERSION: 0.14.6.0
+        NODE_VERSION: 22.4.1
     environment:
       NETWORK: ${NETWORK:-preview}
     volumes:


### PR DESCRIPTION
Dependencies are littered throughout the Dockerfile, which is hard to tracked and update for future iterations. I have separated the dependencies into `docker-compose.yaml` as [args](https://docs.docker.com/reference/compose-file/build/#args) for better control.

I also updated some of these environment variables.

- Ubuntu v20.04 to v22.04
- `libsodium` to latest commit `HEAD`
- GHC, HLS, and Cabal versions
- Nodejs from `16.13.0` to `22.4.1`